### PR TITLE
feat: Implement image metadata extraction

### DIFF
--- a/db/crud.py
+++ b/db/crud.py
@@ -11,6 +11,7 @@ from models import models # Updated import to access Image model and Pydantic sc
 
 # Let's adjust imports for clarity and correctness based on previous steps
 from models.models import Number, Image, ImageCreate, ImageSchema
+from typing import Optional # Added for Optional type hint
 
 def get_number(db: Session):
     return db.query(models.Number).first() # Adjusted to use models.Number
@@ -36,12 +37,25 @@ def increment_number(db: Session):
     return None
 
 # Functions for Image model
-def create_image(db: Session, image: ImageCreate) -> models.Image:
+def create_image(
+    db: Session,
+    image: ImageCreate,
+    width: Optional[int] = None,
+    height: Optional[int] = None,
+    format: Optional[str] = None,
+    exif_orientation: Optional[int] = None,
+    color_profile: Optional[str] = None
+) -> models.Image:
     db_image = models.Image(
         filename=image.filename,
         filepath=image.filepath,
         filesize=image.filesize,
-        mimetype=image.mimetype
+        mimetype=image.mimetype,
+        width=width,
+        height=height,
+        format=format,
+        exif_orientation=exif_orientation,
+        color_profile=color_profile
     )
     db.add(db_image)
     db.commit()

--- a/models/models.py
+++ b/models/models.py
@@ -23,6 +23,11 @@ class Image(Base):
     filepath = Column(String)
     filesize = Column(Integer)
     mimetype = Column(String)
+    width = Column(Integer, nullable=True)
+    height = Column(Integer, nullable=True)
+    format = Column(String, nullable=True)
+    exif_orientation = Column(Integer, nullable=True)
+    color_profile = Column(String, nullable=True)
     rejection_reason = Column(String, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
 
@@ -41,15 +46,25 @@ class NumberSchema(NumberBase):
 # Pydantic schema for creating an Image
 class ImageCreate(BaseModel):
     filename: str
-    filepath: str
+    filepath: Optional[str] = None
     filesize: int
     mimetype: str
+    width: Optional[int] = None
+    height: Optional[int] = None
+    format: Optional[str] = None
+    exif_orientation: Optional[int] = None
+    color_profile: Optional[str] = None
     rejection_reason: Optional[str] = None
 
 # Pydantic schema for reading/returning an Image
 class ImageSchema(ImageCreate): # Inherits fields from ImageCreate
     id: uuid.UUID
     created_at: datetime
+    width: Optional[int] = None
+    height: Optional[int] = None
+    format: Optional[str] = None
+    exif_orientation: Optional[int] = None
+    color_profile: Optional[str] = None
     rejection_reason: Optional[str] = None
 
     class Config:


### PR DESCRIPTION
This commit introduces functionality to extract metadata from uploaded images.

The following metadata is now extracted and stored:
- Image dimensions (width, height)
- Image format (e.g., JPEG, PNG)
- EXIF orientation (if present)
- Color profile (using image mode as a proxy, e.g., RGB, RGBA, or ICC if profile detected)

Changes include:
- Updated the `Image` model and Pydantic schemas (`ImageCreate`, `ImageSchema`) to include fields for the new metadata.
- Modified the `crud.create_image` function to store these new fields in the database.
- Extended the `/api/images/upload` endpoint in `main.py` to use Pillow to extract the metadata during image processing.
- Added comprehensive unit verifications in `tests/test_main.py` to confirm the metadata extraction logic, including handling of images with and without EXIF data, and different image formats.
- Mocked external services (Google Vision) and file system operations in verifications to ensure they are focused and reliable.