### PR TITLE
feat: Implement user registration functionality

### DIFF
--- a/auth_utils.py
+++ b/auth_utils.py
@@ -12,10 +12,19 @@ def hash_password(password: str) -> str:
     return pwd_context.hash(password)
 
 # JWT Creation
-from jose import jwt
+from jose import jwt, JWTError, ExpiredSignatureError
 from datetime import datetime, timedelta
 from typing import Optional
 from config import SECRET_KEY, ALGORITHM, ACCESS_TOKEN_EXPIRE_MINUTES
+from fastapi import HTTPException, status, Depends
+from fastapi.security import OAuth2PasswordBearer
+from sqlalchemy.orm import Session
+from db.database import get_db
+from db import crud
+from models.models import User # For type hinting User model
+
+# OAuth2 scheme
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/login")
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
     to_encode = data.copy()
@@ -26,3 +35,43 @@ def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -
     to_encode.update({"exp": expire})
     encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
+
+# JWT Decoding and Validation
+def decode_access_token(token: str) -> dict:
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        return payload
+    except ExpiredSignatureError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token has expired",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    except JWTError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials", # More generic message for other JWT errors
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+# Dependency to get current user
+def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)) -> User:
+    payload = decode_access_token(token) # This will raise HTTPException if token is invalid/expired
+
+    email: Optional[str] = payload.get("sub")
+    if email is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials - missing user identifier",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    user = crud.get_user_by_email(db, email=email)
+    if user is None:
+        # This case could happen if user was deleted after token was issued
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not found",
+            headers={"WWW-Authenticate": "Bearer"}
+        )
+    return user

--- a/auth_utils.py
+++ b/auth_utils.py
@@ -1,0 +1,12 @@
+from passlib.context import CryptContext
+
+# Create a CryptContext instance configured for bcrypt
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Verifies a plain password against a hashed password."""
+    return pwd_context.verify(plain_password, hashed_password)
+
+def hash_password(password: str) -> str:
+    """Hashes a plain password."""
+    return pwd_context.hash(password)

--- a/auth_utils.py
+++ b/auth_utils.py
@@ -10,3 +10,19 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
 def hash_password(password: str) -> str:
     """Hashes a plain password."""
     return pwd_context.hash(password)
+
+# JWT Creation
+from jose import jwt
+from datetime import datetime, timedelta
+from typing import Optional
+from config import SECRET_KEY, ALGORITHM, ACCESS_TOKEN_EXPIRE_MINUTES
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    to_encode = data.copy()
+    if expires_delta:
+        expire = datetime.utcnow() + expires_delta
+    else:
+        expire = datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt

--- a/config.py
+++ b/config.py
@@ -1,0 +1,9 @@
+# config.py
+
+# IMPORTANT: This is a default secret key for development purposes ONLY.
+# For production, use a strong, randomly generated key and load it from
+# an environment variable or a secure configuration management system.
+SECRET_KEY: str = "your-super-secret-key-please-change-in-production"
+
+ALGORITHM: str = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES: int = 30

--- a/db/crud.py
+++ b/db/crud.py
@@ -77,3 +77,6 @@ def create_user(db: Session, user: UserCreate) -> User:
     db.commit()
     db.refresh(db_user)
     return db_user
+
+def get_user_by_id(db: Session, user_id: uuid.UUID) -> Optional[User]:
+    return db.query(User).filter(User.id == user_id).first()

--- a/db/crud.py
+++ b/db/crud.py
@@ -10,8 +10,9 @@ from models import models # Updated import to access Image model and Pydantic sc
 # or if .database still correctly provides it (which it does after previous subtask)
 
 # Let's adjust imports for clarity and correctness based on previous steps
-from models.models import Number, Image, ImageCreate, ImageSchema
+from models.models import Number, Image, ImageCreate, ImageSchema, User, UserCreate
 from typing import Optional # Added for Optional type hint
+from auth_utils import hash_password
 
 def get_number(db: Session):
     return db.query(models.Number).first() # Adjusted to use models.Number
@@ -64,3 +65,15 @@ def create_image(
 
 def get_image(db: Session, image_id: uuid.UUID) -> models.Image | None:
     return db.query(models.Image).filter(models.Image.id == image_id).first()
+
+# Functions for User model
+def get_user_by_email(db: Session, email: str) -> Optional[User]:
+    return db.query(User).filter(User.email == email).first()
+
+def create_user(db: Session, user: UserCreate) -> User:
+    hashed_pass = hash_password(user.password)
+    db_user = User(email=user.email, hashed_password=hashed_pass)
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user

--- a/db/database.py
+++ b/db/database.py
@@ -1,6 +1,6 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from models.models import Base, Number, Image # Import Base and models
+from models.models import Base, Number, Image, User # Import Base and models
 
 DATABASE_URL = "sqlite:///./sql_app.db" # Changed Database URL
 

--- a/main.py
+++ b/main.py
@@ -28,6 +28,8 @@ from services.image_quality import analyze_image_quality # New import
 from services.auto_enhancement import calculate_auto_enhancements # New import for auto enhancement
 from services.image_processing import apply_enhancements, ImageProcessingError # New import for applying enhancements
 
+from routers import auth as auth_router # Import the auth router
+
 # Pydantic model for content moderation result
 class ContentModerationResult(BaseModel): # Corrected to BaseModel
     is_approved: bool
@@ -89,6 +91,7 @@ class ProcessedImageResponse(BaseModel):
     error: Optional[str] = None
 
 app = FastAPI()
+app.include_router(auth_router.router) # Include the auth router
 
 # Configure basic logging
 logging.basicConfig(level=logging.INFO)

--- a/main.py
+++ b/main.py
@@ -29,6 +29,7 @@ from services.auto_enhancement import calculate_auto_enhancements # New import f
 from services.image_processing import apply_enhancements, ImageProcessingError # New import for applying enhancements
 
 from routers import auth as auth_router # Import the auth router
+from routers import users as users_router # Import the users router
 
 # Pydantic model for content moderation result
 class ContentModerationResult(BaseModel): # Corrected to BaseModel
@@ -92,6 +93,7 @@ class ProcessedImageResponse(BaseModel):
 
 app = FastAPI()
 app.include_router(auth_router.router) # Include the auth router
+app.include_router(users_router.router) # Include the users router
 
 # Configure basic logging
 logging.basicConfig(level=logging.INFO)

--- a/models/models.py
+++ b/models/models.py
@@ -5,7 +5,7 @@ from typing import Optional
 from sqlalchemy import Column, DateTime, Integer, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.declarative import declarative_base
-from pydantic import BaseModel
+from pydantic import BaseModel, EmailStr
 
 Base = declarative_base()
 
@@ -30,6 +30,31 @@ class Image(Base):
     color_profile = Column(String, nullable=True)
     rejection_reason = Column(String, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    email = Column(String, unique=True, index=True, nullable=False)
+    hashed_password = Column(String, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+
+# Pydantic schemas for User
+class UserBase(BaseModel):
+    email: EmailStr
+
+class UserCreate(UserBase):
+    password: str # min_length=8 will be handled by endpoint logic
+
+class UserSchema(UserBase):
+    id: uuid.UUID
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
 
 class NumberBase(BaseModel):
     value: int

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ numpy
 mediapipe
 passlib[bcrypt]
 email-validator
+python-jose[cryptography]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ Pillow>=9.0.0
 opencv-python
 numpy
 mediapipe
+passlib[bcrypt]
+email-validator

--- a/routers/auth.py
+++ b/routers/auth.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from db.database import get_db
+from db import crud
+from models.models import UserCreate, UserSchema
+from auth_utils import hash_password # Though create_user handles hashing, good to be aware
+
+router = APIRouter(
+    prefix="/api/auth",
+    tags=["auth"],
+    responses={404: {"description": "Not found"}},
+)
+
+@router.post("/register", response_model=UserSchema, status_code=status.HTTP_201_CREATED)
+def register_user(user: UserCreate, db: Session = Depends(get_db)):
+    # Password Strength Check
+    if len(user.password) < 8:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Password must be at least 8 characters long.",
+        )
+
+    # Check for existing user
+    db_user = crud.get_user_by_email(db, email=user.email)
+    if db_user:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Email already registered",
+        )
+
+    # Create user (hashing is done within crud.create_user)
+    created_user = crud.create_user(db=db, user=user)
+    return created_user

--- a/routers/auth.py
+++ b/routers/auth.py
@@ -1,10 +1,11 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
+from fastapi.security import OAuth2PasswordRequestForm
 from db.database import get_db
 from db import crud
-from models.models import UserCreate, UserSchema
-from auth_utils import hash_password # Though create_user handles hashing, good to be aware
+from models.models import UserCreate, UserSchema # User model itself is used via crud.get_user_by_email
+from auth_utils import verify_password, create_access_token
 
 router = APIRouter(
     prefix="/api/auth",
@@ -32,3 +33,21 @@ def register_user(user: UserCreate, db: Session = Depends(get_db)):
     # Create user (hashing is done within crud.create_user)
     created_user = crud.create_user(db=db, user=user)
     return created_user
+
+@router.post("/login") # Or use "/token" for OAuth2 convention
+async def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)):
+    user = crud.get_user_by_email(db, email=form_data.username)
+    if not user or not verify_password(form_data.password, user.hashed_password):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect email or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    # Ensure user.id is a string for JWT if it's a UUID object
+    user_id_str = str(user.id)
+
+    access_token_data = {"sub": user.email, "user_id": user_id_str}
+    access_token = create_access_token(data=access_token_data)
+
+    return {"access_token": access_token, "token_type": "bearer"}

--- a/routers/users.py
+++ b/routers/users.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, Depends
+from models.models import User, UserSchema # User is the SQLAlchemy model, UserSchema is Pydantic
+from auth_utils import get_current_user
+
+router = APIRouter(
+    prefix="/api/users",
+    tags=["users"],
+    responses={404: {"description": "Not found"}},
+)
+
+@router.get("/me", response_model=UserSchema)
+async def read_users_me(current_user: User = Depends(get_current_user)):
+    """
+    Get current authenticated user.
+    """
+    return current_user

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,141 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+import uuid
+
+# Ensure the app's modules can be imported
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from main import app
+from db.database import SessionLocal, create_db_and_tables
+from models.models import User as UserModel # Renamed to avoid conflict with User schema if any
+from auth_utils import verify_password # To check if password is not plain
+
+# Create tables if they don't exist (e.g., for in-memory DB or first run)
+# This is generally handled by main.py on startup, but explicit call can be useful
+# For tests, it's better to manage this with test-specific setup/teardown
+# For now, we rely on main.py's startup event or manual creation if needed.
+# create_db_and_tables() # Usually, you'd have a separate test DB setup
+
+client = TestClient(app)
+
+# Helper to get a DB session
+def get_test_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+# Fixture for DB session (optional, could also use get_test_db directly)
+@pytest.fixture(scope="module") # module scope if DB is reset per module, function if per test
+def db_session():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+def clear_user_from_db(db: Session, email: str):
+    user = db.query(UserModel).filter(UserModel.email == email).first()
+    if user:
+        db.delete(user)
+        db.commit()
+
+@pytest.fixture(autouse=True)
+def auto_clear_db_after_test(db_session: Session):
+    """Ensures the DB is clean after each test that might create users."""
+    # This is a simplistic cleanup. Ideally, use transactions and rollback,
+    # or a dedicated test DB that's reset.
+    # For this example, we'll try to clean up known test users.
+    # This is tricky if emails are dynamically generated and not tracked.
+    # A better approach is to override get_db with a test DB that rolls back.
+    # For now, we'll rely on specific test functions to clean up if they create data.
+    yield
+
+
+def test_register_user_success(db_session: Session):
+    unique_email = f"test_success_{uuid.uuid4()}@example.com"
+    password = "validpassword123"
+
+    response = client.post(
+        "/api/auth/register",
+        json={"email": unique_email, "password": password},
+    )
+
+    assert response.status_code == 201, response.text
+    data = response.json()
+    assert data["email"] == unique_email
+    assert "id" in data
+    assert "hashed_password" not in data # IMPORTANT: Hashed password should not be in response
+    assert "created_at" in data
+
+    # Verify in DB
+    user_in_db = db_session.query(UserModel).filter(UserModel.email == unique_email).first()
+    assert user_in_db is not None
+    assert user_in_db.email == unique_email
+    assert verify_password(password, user_in_db.hashed_password) # Check if password was hashed correctly
+    assert not verify_password(password + "wrong", user_in_db.hashed_password) # Double check
+
+    # Cleanup
+    clear_user_from_db(db_session, unique_email)
+
+
+def test_register_user_duplicate_email(db_session: Session):
+    duplicate_email = f"test_duplicate_{uuid.uuid4()}@example.com"
+    password = "validpassword123"
+
+    # Create user first
+    client.post(
+        "/api/auth/register",
+        json={"email": duplicate_email, "password": password},
+    )
+
+    # Attempt to register again with the same email
+    response = client.post(
+        "/api/auth/register",
+        json={"email": duplicate_email, "password": "anotherpassword"},
+    )
+
+    assert response.status_code == 409, response.text
+    data = response.json()
+    assert data["detail"] == "Email already registered"
+
+    # Cleanup
+    clear_user_from_db(db_session, duplicate_email)
+
+
+def test_register_user_invalid_email_format():
+    response = client.post(
+        "/api/auth/register",
+        json={"email": "invalid-email", "password": "validpassword123"},
+    )
+
+    assert response.status_code == 422, response.text
+    data = response.json()
+    # Pydantic's error messages can be nested. Check for 'email' field error.
+    assert any(err["loc"] == ["body", "email"] for err in data["detail"])
+
+
+def test_register_user_weak_password():
+    response = client.post(
+        "/api/auth/register",
+        json={"email": f"test_weak_pw_{uuid.uuid4()}@example.com", "password": "pw"},
+    )
+
+    assert response.status_code == 422, response.text
+    data = response.json()
+    assert data["detail"] == "Password must be at least 8 characters long."
+
+# Note: For a robust test suite, especially with database interactions:
+# 1. Use a separate test database (e.g., in-memory SQLite or a dedicated test PostgreSQL DB).
+#    This can be configured by overriding the `get_db` dependency in FastAPI for tests.
+# 2. Ensure each test runs in a transaction that is rolled back afterwards to maintain isolation.
+#    FastAPI's TestClient and dependency overrides can facilitate this.
+# The current cleanup (`clear_user_from_db`) is a basic workaround.
+# The `sys.path.insert` is a common way to handle imports in tests when running from the tests directory.
+# Ideally, project structure and PYTHONPATH should be set up so this isn't strictly necessary,
+# e.g., by installing the package in editable mode (`pip install -e .`) or configuring the test runner.
+# Running `pytest` from the project root directory is usually the best practice.

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,125 @@
+import pytest
+from fastapi.testclient import TestClient
+from fastapi import status
+from sqlalchemy.orm import Session
+import uuid
+from datetime import timedelta
+import os
+import sys
+
+# Ensure the app's modules can be imported
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from main import app
+from models.models import User
+from auth_utils import hash_password, create_access_token # create_access_token for expired token test
+from db.database import SessionLocal # For db_session fixture
+
+# Client fixture
+@pytest.fixture(scope="module")
+def client():
+    # Create tables if they don't exist. This is important if using an in-memory DB
+    # or if the main app's startup event hasn't run.
+    # from db.database import create_db_and_tables
+    # create_db_and_tables() # Usually handled by app startup or a global test setup
+    return TestClient(app)
+
+# DB session fixture
+@pytest.fixture(scope="function")
+def db_session():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+# Utility to clear users (could be in a conftest.py or shared utils)
+def clear_user_from_db(db: Session, email: str):
+    user = db.query(User).filter(User.email == email).first()
+    if user:
+        db.delete(user)
+        db.commit()
+
+# Test user factory fixture
+@pytest.fixture(scope="function")
+def test_user_factory(db_session: Session):
+    created_users_emails = []
+    def _create_user(email_prefix="testuser_me"): # Changed prefix to avoid collision with test_auth
+        unique_email = f"{email_prefix}_{uuid.uuid4()}@example.com"
+        password = "TestPassword123" # Consistent password for factory-created users
+        hashed_pw = hash_password(password)
+
+        user = User(email=unique_email, hashed_password=hashed_pw)
+        db_session.add(user)
+        db_session.commit()
+        db_session.refresh(user)
+        created_users_emails.append(user.email)
+        return {"email": user.email, "password": password, "id": str(user.id)}
+
+    yield _create_user
+
+    # Cleanup all users created by this factory instance during a test
+    for email in created_users_emails:
+        clear_user_from_db(db_session, email)
+
+# Access token factory fixture
+@pytest.fixture(scope="function")
+def access_token_factory(client: TestClient): # Removed test_user_factory dependency here, pass user_details directly
+    def _get_token(user_details: dict): # Expects dict with 'email' and 'password'
+        login_data = {"username": user_details["email"], "password": user_details["password"]}
+        response = client.post("/api/auth/login", data=login_data)
+        assert response.status_code == 200, f"Login failed for token generation: {response.text}"
+        return response.json()["access_token"]
+    return _get_token
+
+
+# Tests for /api/users/me
+def test_access_users_me_no_token(client: TestClient):
+    response = client.get("/api/users/me")
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    # FastAPI's default for missing OAuth2 token is usually 403 if scheme is just checked,
+    # but our oauth2_scheme and get_current_user should enforce 401 if token is not provided.
+    # If it returns 403, it means the dependency `oauth2_scheme` itself raised it.
+    # Let's verify the detail if possible, usually "Not authenticated" or similar from scheme.
+    # For now, 401 is the primary check based on how get_current_user is structured.
+
+def test_access_users_me_with_valid_token(client: TestClient, test_user_factory, access_token_factory):
+    user_details = test_user_factory() # Create a user
+    token = access_token_factory(user_details) # Get token for that user
+
+    response = client.get(
+        "/api/users/me",
+        headers={"Authorization": f"Bearer {token}"}
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["email"] == user_details["email"]
+    assert data["id"] == user_details["id"]
+    assert "hashed_password" not in data # Ensure sensitive data is not returned
+
+def test_access_users_me_with_invalid_signature_token(client: TestClient):
+    response = client.get(
+        "/api/users/me",
+        headers={"Authorization": "Bearer aninvalidtokenstringthatisnotjwt"}
+    )
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    # The detail might vary depending on where the JWTError is caught,
+    # but auth_utils.decode_access_token should provide "Could not validate credentials".
+    assert response.json()["detail"] == "Could not validate credentials"
+
+
+def test_access_users_me_with_expired_token(client: TestClient, test_user_factory):
+    user_details = test_user_factory() # Create a user
+
+    # Create an already expired token
+    expired_token = create_access_token(
+        data={"sub": user_details["email"], "user_id": user_details["id"]},
+        expires_delta=timedelta(seconds=-3600) # 1 hour in the past
+    )
+
+    response = client.get(
+        "/api/users/me",
+        headers={"Authorization": f"Bearer {expired_token}"}
+    )
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json()["detail"] == "Token has expired"


### PR DESCRIPTION
This commit introduces user registration capabilities to the application.

Key changes include:
- Added a `User` model (`models/models.py`) with fields for ID, email, hashed password, and creation timestamp.
- Defined Pydantic schemas (`UserCreate`, `UserSchema`) for request validation and response serialization.
- Implemented password hashing and verification utilities (`auth_utils.py`) using `passlib` with bcrypt.
- Added CRUD operations for users (`db/crud.py`) to create users and retrieve them by email.
- Updated database initialization (`db/database.py`) to ensure the `User` table is created.
- Created a new FastAPI router (`routers/auth.py`) with a `/api/auth/register` endpoint:
    - Validates email format (using Pydantic's `EmailStr`).
    - Enforces a minimum password length of 8 characters.
    - Checks for email uniqueness to prevent duplicate registrations.
    - Stores passwords securely hashed.
    - Returns appropriate HTTP status codes (201, 409, 422).
- Added `passlib[bcrypt]` and `email-validator` to `requirements.txt`.
- Included comprehensive unit tests (`tests/test_auth.py`) for the registration endpoint, covering success cases, duplicate emails, invalid email formats, and weak passwords.